### PR TITLE
Fix crash on latest Geyser due to uppercase item ID "BASE"

### DIFF
--- a/src/main/java/com/redmondstudio/slimefungeyser/Slimefun.java
+++ b/src/main/java/com/redmondstudio/slimefungeyser/Slimefun.java
@@ -136,12 +136,12 @@ public class Slimefun implements Extension {
 		// PLAYER_HEAD
 		//
 		
-		CustomItemData BASE = CustomItemData.builder()
-                .name("BASE")
-                .customItemOptions(CustomItemOptions.builder().customModelData(1111).build())
-                .textureSize(16)
-                .build();
-        event.register("minecraft:player_head", BASE);
+		CustomItemData base = CustomItemData.builder()
+        .name("base")
+        .customItemOptions(CustomItemOptions.builder().customModelData(1111).build())
+        .textureSize(16)
+        .build();
+event.register("minecraft:player_head", base);
 		
 		CustomItemData wiki = CustomItemData.builder()
                 .name("wiki")


### PR DESCRIPTION
This PR fixes a critical crash when using the latest version of Geyser. Geyser now strictly validates custom item IDs and throws an IllegalArgumentException if they contain uppercase characters.

The item ID "BASE" in Slimefun.java was causing the server to crash on startup with: java.lang.IllegalArgumentException: Non [a-z0-9_\-./]+ character in value of Key[geyser_custom:BASE]

I have changed the item ID to "base" (lowercase) to comply with Geyser's new validation rules.

Steps to verify:

1. Update to the latest Geyser build.
2. Run the extension without this fix -> Server crashes.
3. Run the extension with this fix -> Server starts successfully.